### PR TITLE
Use static shared URLSession to avoid memory leaks

### DIFF
--- a/Sources/SwiftEvolutionBackend/Services/Network.swift
+++ b/Sources/SwiftEvolutionBackend/Services/Network.swift
@@ -5,13 +5,15 @@ class Service {
     public typealias CompletionProposalsHandler = (_ error: Error?, _ proposals: Data?) -> Void
     public typealias CompletionProposalHandler = (_ error: Error?, _ proposalText: String?) -> Void
 
+    static let sharedSession = URLSession(configuration: .default)
+    
     /**
      Request all proposals from Swift Evolution from data.swift.org
      
      - returns: proposals list or nil
      */
     static func getProposals(_ handler: @escaping CompletionProposalsHandler) {
-        let session = URLSession(configuration: .default)
+        let session = Service.sharedSession
 
         if let url = URL(string: Config.shared.rawProposalsBaseURL) {
             let datatask = session.dataTask(with: url) { (data, _, error) in
@@ -33,7 +35,7 @@ class Service {
 
     static func getProposalText(_ proposalLink: String, handler: @escaping CompletionProposalHandler) {
 
-        let session = URLSession(configuration: .default)
+        let session = Service.sharedSession
 
         if let url = URL(string: proposalLink) {
 


### PR DESCRIPTION
Here in [this link](https://stackoverflow.com/a/35757989/1434092) you can get a better explanation why creating a new `URLSession` for every request creates memory leaks.

As far as I know `URLSession.shared` is not available on Linux, so I just created a static shared session that can be used across the application.