### PR TITLE
Add missing next() call to getProposals

### DIFF
--- a/Sources/SwiftEvolutionBackend/Controller/ProposalsController.swift
+++ b/Sources/SwiftEvolutionBackend/Controller/ProposalsController.swift
@@ -91,6 +91,7 @@ extension Controller {
         processProposals(response: response) {
             let json = JSON(data: self.proposalCache.rawData)
             response.status(.OK).send(json: json)
+            next()
         }
     }
 


### PR DESCRIPTION
This PR doesn't fix any current bug because the completion closure of `getProposals` has not been used yet. However, since the closure is defined as an argument we have to ensure it's been called in the end of the execution, otherwise it will lead to bugs in the future.